### PR TITLE
SW-640 - change-octoprint-update

### DIFF
--- a/docs/sw-update-conf.json
+++ b/docs/sw-update-conf.json
@@ -59,6 +59,13 @@
     "octoprint": {
       "type": "github_release",
       "develop": {
+        "type": "github_commit",
+        "branch": "alpha",
+        "branch_default": "alpha"
+      },
+      "alpha": {
+        "branch": "alpha",
+        "branch_default": "alpha",
         "type": "github_commit"
       }
     },


### PR DESCRIPTION
change the update of octoprint to fetch github_commits from alpha branch for develop and alpha tier